### PR TITLE
update to work with android

### DIFF
--- a/src/main/java/io/github/givimad/whisperjni/WhisperGrammar.java
+++ b/src/main/java/io/github/givimad/whisperjni/WhisperGrammar.java
@@ -54,7 +54,7 @@ public class WhisperGrammar extends WhisperJNI.WhisperJNIPointer {
         if (!Files.exists(grammar)) {
             throw new ParseException("Grammar file does not exists.", 0);
         }
-        assertValidGrammar(Files.readString(grammar));
+        assertValidGrammar(new String(Files.readAllBytes(grammar)));
     }
 
     /**

--- a/src/main/java/io/github/givimad/whisperjni/WhisperJNI.java
+++ b/src/main/java/io/github/givimad/whisperjni/WhisperJNI.java
@@ -142,7 +142,7 @@ public class WhisperJNI {
         if(!Files.exists(grammarPath) || Files.isDirectory(grammarPath)){
             throw new FileNotFoundException("Grammar file not found");
         }
-        return parseGrammar(Files.readString(grammarPath));
+        return parseGrammar(new String(Files.readAllBytes(grammarPath)));
     }
 
     public WhisperGrammar parseGrammar(String text) throws IOException {

--- a/src/main/java/io/github/givimad/whisperjni/internal/LibraryUtils.java
+++ b/src/main/java/io/github/givimad/whisperjni/internal/LibraryUtils.java
@@ -133,7 +133,7 @@ public class LibraryUtils {
             wrapperLibName = "libwhisper-jni.so";
             String cpuInfo;
             try {
-                cpuInfo = Files.readString(Path.of("/proc/cpuinfo"));
+                cpuInfo = new String(Files.readAllBytes(Path.of("/proc/cpuinfo")));
             } catch (IOException ignored) {
                 cpuInfo = "";
             }


### PR DESCRIPTION
See #19 - the `java.nio.file.Files.readString` method is not supported in android for whatever reason, but the Java 8 version of the equivalent functionality _is_, and so I've replaced usages of the `readString` method which would work similarly.

I'm not sure if this commit works with your CI (e.g. versioning, etc), so I'll leave changing that up to you if this change works!