### PR TITLE
Fix typo. bean search → beam search

### DIFF
--- a/src/main/java/io/github/givimad/whisperjni/WhisperFullParams.java
+++ b/src/main/java/io/github/givimad/whisperjni/WhisperFullParams.java
@@ -89,7 +89,7 @@ public class WhisperFullParams {
     public float temperature = 0.0f;
     /**
      * Refer to library
-     */    
+     */
     public float maxInitialTs = 1.0f;
     /**
      * Refer to library
@@ -116,15 +116,15 @@ public class WhisperFullParams {
      */
     public int greedyBestOf = -1;
     /**
-     * Specific to bean search sampling strategy
+     * Specific to beam search sampling strategy
      */
     public int beamSearchBeamSize = 2;
     /**
-     * Specific to bean search sampling strategy
+     * Specific to beam search sampling strategy
      */
     public float beamSearchPatience = -1.0f;
     /**
-     * GBNF grammar. 
+     * GBNF grammar.
      */
     public WhisperGrammar grammar;
     /**
@@ -144,6 +144,6 @@ public class WhisperFullParams {
      * Creates a new {@link WhisperFullParams} instance using the greedy {@link WhisperSamplingStrategy}
      */
     public WhisperFullParams() {
-        this(WhisperSamplingStrategy.BEAN_SEARCH);
+        this(WhisperSamplingStrategy.BEAM_SEARCH);
     }
 }

--- a/src/main/java/io/github/givimad/whisperjni/WhisperSamplingStrategy.java
+++ b/src/main/java/io/github/givimad/whisperjni/WhisperSamplingStrategy.java
@@ -12,5 +12,5 @@ public enum WhisperSamplingStrategy {
     /**
      * Similar to OpenAI's BeamSearchDecoder
      */
-    BEAN_SEARCH;
+    BEAM_SEARCH;
 }

--- a/src/test/java/io/github/givimad/whisperjni/WhisperJNITest.java
+++ b/src/test/java/io/github/givimad/whisperjni/WhisperJNITest.java
@@ -113,11 +113,11 @@ public class WhisperJNITest {
     }
 
     @Test
-    public void testFullBeanSearch() throws Exception {
+    public void testFullBeamSearch() throws Exception {
         float[] samples = readJFKFileSamples();
         try (var ctx = whisper.init(testModelPath)) {
             assertNotNull(ctx);
-            var params = new WhisperFullParams(WhisperSamplingStrategy.BEAN_SEARCH);
+            var params = new WhisperFullParams(WhisperSamplingStrategy.BEAM_SEARCH);
             params.printTimestamps = false;
             int result = whisper.full(ctx, params, samples, samples.length);
             if(result != 0) {
@@ -154,11 +154,11 @@ public class WhisperJNITest {
     }
 
     @Test
-    public void testFullWithStateBeanSearch() throws Exception {
+    public void testFullWithStateBeamSearch() throws Exception {
         float[] samples = readJFKFileSamples();
         try (var ctx = whisper.initNoState(testModelPath)) {
             assertNotNull(ctx);
-            var params = new WhisperFullParams(WhisperSamplingStrategy.BEAN_SEARCH);
+            var params = new WhisperFullParams(WhisperSamplingStrategy.BEAM_SEARCH);
             params.printTimestamps = false;
             try (var state = whisper.initState(ctx)) {
                 assertNotNull(state);


### PR DESCRIPTION
I thought it was probably a typo.

bean search → beam search