### PR TITLE
Handle invalid system paths in library loading

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,5 @@
 name: CI
 on:
-  push:
-    tags: [ "v*.*.*", "v*.*.*-*" ]
   workflow_dispatch:
 jobs:
   download-model:

--- a/src/main/java/io/github/givimad/whisperjni/internal/LibraryUtils.java
+++ b/src/main/java/io/github/givimad/whisperjni/internal/LibraryUtils.java
@@ -204,14 +204,27 @@ public class LibraryUtils {
         }
         return builder.build();
     }
+    
     private static boolean isWhisperDLLInstalled() {
-        return Arrays
-                .stream(System.getenv("PATH").split(";"))
-                .map(Paths::get)
-                .map(p -> p.resolve("whisper.dll"))
-                .anyMatch(Files::exists);
+        String pathEnv = System.getenv("PATH");
+        if (pathEnv == null || pathEnv.isEmpty()) {
+            return false;
+        }
+        
+        return Arrays.stream(pathEnv.split(Pattern.quote(File.pathSeparator)))
+                     .map(String::trim)
+                     .filter(s -> !s.isEmpty())
+                     .map(path -> {
+                         try {
+                             return Paths.get(path).resolve("whisper.dll");
+                         } catch (InvalidPathException e) {
+                             return null; // skip invalid path
+                         }
+                     })
+                     .filter(Objects::nonNull)
+                     .anyMatch(Files::exists);
     }
-
+    
     private static final class LibraryPaths {
         final String whisperJNIPath;
         final String whisperJNIFilename;

--- a/src/main/java/io/github/givimad/whisperjni/internal/LibraryUtils.java
+++ b/src/main/java/io/github/givimad/whisperjni/internal/LibraryUtils.java
@@ -1,7 +1,5 @@
 package io.github.givimad.whisperjni.internal;
 
-import io.github.givimad.whisperjni.WhisperJNI;
-
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -12,6 +10,10 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.Arrays;
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+import io.github.givimad.whisperjni.WhisperJNI;
 
 
 public class LibraryUtils {
@@ -218,7 +220,7 @@ public class LibraryUtils {
                          try {
                              return Paths.get(path).resolve("whisper.dll");
                          } catch (InvalidPathException e) {
-                             return null; // skip invalid path
+                             return null;
                          }
                      })
                      .filter(Objects::nonNull)


### PR DESCRIPTION
If **System.env("PATH")** has malformed paths, `LibraryUtils.isWhisperDLLInstalled` will throw an `InvalidPathException`. This adds a try catch in resolving the paths so it won't fail loading natives if path is malformed.